### PR TITLE
dynamic page generation

### DIFF
--- a/harrier/build.py
+++ b/harrier/build.py
@@ -53,7 +53,7 @@ class BuildPages:
         for p in paths:
             if p.is_file():
                 try:
-                    v = self.prep_file(p)
+                    path_ref, v = self.prep_file(p)
                 except ExtensionError:
                     # these are logged directly
                     raise
@@ -61,14 +61,14 @@ class BuildPages:
                     logger.exception('%s: error building SOM for page', p)
                     raise
                 if v:
-                    pages['/' + str(p.relative_to(self.config.pages_dir))] = v
+                    pages[path_ref] = v
         logger.debug('Built site object model with %d files, %d files to render', self.files, self.template_files)
         return pages, self.files
 
     def prep_file(self, p):
         path_ref = norm_path_ref(p, self.config.pages_dir)
         if any(path_match(path_ref) for path_match in self.config.ignore):
-            return
+            return path_ref, None
 
         data, pass_through = self.get_page_data(p, path_ref)
 
@@ -92,7 +92,7 @@ class BuildPages:
         if not pass_through:
             self.template_files += 1
 
-        return final_data
+        return path_ref, final_data
 
     def get_page_data(self, p, path_ref):  # noqa: C901 (ignore complexity)
         html_output = p.suffix in OUTPUT_HTML

--- a/harrier/build.py
+++ b/harrier/build.py
@@ -53,7 +53,7 @@ class BuildPages:
         for p in paths:
             if p.is_file():
                 try:
-                    path_ref, v = self.prep_file(p)
+                    v = get_page_data(p, config=self.config)
                 except ExtensionError:
                     # these are logged directly
                     raise
@@ -61,93 +61,94 @@ class BuildPages:
                     logger.exception('%s: error building SOM for page', p)
                     raise
                 if v:
+                    # logger.debug('added %s pass_through: %s, outfile %s', p, pass_through, fd.outfile)
+                    self.files += 1
+                    if not v['pass_through']:
+                        self.template_files += 1
+                    path_ref = v.pop('path_ref')
                     pages[path_ref] = v
         logger.debug('Built site object model with %d files, %d files to render', self.files, self.template_files)
         return pages, self.files
 
-    def prep_file(self, p):
-        path_ref = norm_path_ref(p, self.config.pages_dir)
-        if any(path_match(path_ref) for path_match in self.config.ignore):
-            return path_ref, None
 
-        data, pass_through = self.get_page_data(p, path_ref)
+def get_page_data(p, *, config: Config, content: str=None, **extra_data):  # noqa: C901 (ignore complexity)
+    path_ref = norm_path_ref(p, config.pages_dir)
+    if any(path_match(path_ref) for path_match in config.ignore):
+        return
 
-        for path_match, f in self.config.extensions.page_modifiers:
-            if path_match(path_ref):
-                try:
-                    data = f(data, config=self.config)
-                except Exception as e:
-                    logger.exception('%s error running page extension %s', p, f.__name__)
-                    raise ExtensionError(str(e)) from e
-                if not isinstance(data, dict):
-                    logger.error('%s extension "%s" did not return a dict', p, f.__name__)
-                    raise ExtensionError(f'extension "{f.__name__}" did not return a dict')
+    html_output = p.suffix in OUTPUT_HTML
+    maybe_render = p.suffix in MAYBE_RENDER
+    name = p.stem if html_output else p.name
 
-        fd = FileData(**data)
-        final_data = fd.dict(exclude={'template', 'render'} if pass_through else set())
-        final_data['pass_through'] = bool(pass_through)
+    date_match = DATE_REGEX.match(name)
+    if date_match:
+        *date_args, new_name = date_match.groups()
+        created = datetime(*map(int, date_args))
+        name = new_name or name
+    elif content is not None:
+        # file will not actually exist
+        created = datetime.now()
+    else:
+        created = p.stat().st_mtime
 
-        # logger.debug('added %s pass_through: %s, outfile %s', p, pass_through, fd.outfile)
-        self.files += 1
-        if not pass_through:
-            self.template_files += 1
+    data = {
+        'path_ref': path_ref,
+        'infile': p,
+        'template': config.default_template,
+        'title': name,
+        'slug': '' if html_output and p.stem == 'index' else slugify(name),
+        'created': created,
+    }
 
-        return path_ref, final_data
+    for path_match, defaults in config.defaults.items():
+        if path_match(path_ref):
+            data.update(defaults)
 
-    def get_page_data(self, p, path_ref):  # noqa: C901 (ignore complexity)
-        html_output = p.suffix in OUTPUT_HTML
-        maybe_render = p.suffix in MAYBE_RENDER
-        name = p.stem if html_output else p.name
+    pass_through = data.get('pass_through')
+    if not pass_through and (html_output or maybe_render):
+        fm_data, content = parse_front_matter(content or p.read_text())
+        if html_output or fm_data:
+            data['content'] = content
+            fm_data and data.update(fm_data)
 
-        date_match = DATE_REGEX.match(name)
-        if date_match:
-            *date_args, new_name = date_match.groups()
-            created = datetime(*map(int, date_args))
-            name = new_name or name
+    if 'content' not in data:
+        pass_through = True
+
+    data.update(extra_data)
+    uri = data.get('uri')
+    if not uri:
+        parents = str(p.parent.relative_to(config.pages_dir)).split('/')
+        if parents == ['.']:
+            data['uri'] = '/' + data['slug']
         else:
-            created = p.stat().st_mtime
+            data['uri'] = '/' + '/'.join([slugify(p) for p in parents] + [data['slug']])
+    elif URI_IS_TEMPLATE.search(uri):
+        try:
+            data['uri'] = slugify(uri.format(**data))
+        except KeyError as e:
+            raise KeyError(f'missing format variable "{e.args[0]}" for "{uri}"')
 
-        data = {
-            'infile': p,
-            'template': self.config.default_template,
-            'title': name,
-            'slug': '' if html_output and p.stem == 'index' else slugify(name),
-            'created': created,
-        }
+    if data.get('output', True):
+        outfile = config.dist_dir / data['uri'][1:]
+        if html_output and outfile.suffix != '.html':
+            outfile /= 'index.html'
+        data['outfile'] = outfile
 
-        for path_match, defaults in self.config.defaults.items():
-            if path_match(path_ref):
-                data.update(defaults)
-
-        pass_through = data.get('pass_through')
-        if not pass_through and (html_output or maybe_render):
-            fm_data, content = parse_front_matter(p.read_text())
-            if html_output or fm_data:
-                data['content'] = content
-                fm_data and data.update(fm_data)
-
-        if 'content' not in data:
-            pass_through = True
-
-        uri = data.get('uri')
-        if not uri:
-            parents = str(p.parent.relative_to(self.config.pages_dir)).split('/')
-            if parents == ['.']:
-                data['uri'] = '/' + data['slug']
-            else:
-                data['uri'] = '/' + '/'.join([slugify(p) for p in parents] + [data['slug']])
-        elif URI_IS_TEMPLATE.search(uri):
+    for path_match, f in config.extensions.page_modifiers:
+        if path_match(path_ref):
             try:
-                data['uri'] = slugify(uri.format(**data))
-            except KeyError as e:
-                raise KeyError(f'missing format variable "{e.args[0]}" for "{uri}"')
+                data = f(data, config=config)
+            except Exception as e:
+                logger.exception('%s error running page extension %s', p, f.__name__)
+                raise ExtensionError(str(e)) from e
+            if not isinstance(data, dict):
+                logger.error('%s extension "%s" did not return a dict', p, f.__name__)
+                raise ExtensionError(f'extension "{f.__name__}" did not return a dict')
 
-        if data.get('output', True):
-            outfile = self.config.dist_dir / data['uri'][1:]
-            if html_output and outfile.suffix != '.html':
-                outfile /= 'index.html'
-            data['outfile'] = outfile
-        return data, pass_through
+    fd = FileData(**data)
+    final_data = fd.dict(exclude={'template'} if pass_through else set())
+    final_data['pass_through'] = bool(pass_through)
+    return final_data
 
 
 class FileData(BaseModel):

--- a/harrier/build.py
+++ b/harrier/build.py
@@ -71,7 +71,7 @@ class BuildPages:
         return pages, self.files
 
 
-def get_page_data(p, *, config: Config, content: str=None, **extra_data):  # noqa: C901 (ignore complexity)
+def get_page_data(p, *, config: Config, file_content: str=None, **extra_data):  # noqa: C901 (ignore complexity)
     path_ref = norm_path_ref(p, config.pages_dir)
     if any(path_match(path_ref) for path_match in config.ignore):
         return
@@ -85,7 +85,7 @@ def get_page_data(p, *, config: Config, content: str=None, **extra_data):  # noq
         *date_args, new_name = date_match.groups()
         created = datetime(*map(int, date_args))
         name = new_name or name
-    elif content is not None:
+    elif file_content is not None:
         # file will not actually exist
         created = datetime.now()
     else:
@@ -106,7 +106,7 @@ def get_page_data(p, *, config: Config, content: str=None, **extra_data):  # noq
 
     pass_through = data.get('pass_through')
     if not pass_through and (html_output or maybe_render):
-        fm_data, content = parse_front_matter(content or p.read_text())
+        fm_data, content = parse_front_matter(file_content if file_content is not None else p.read_text())
         if html_output or fm_data:
             data['content'] = content
             fm_data and data.update(fm_data)

--- a/harrier/data.py
+++ b/harrier/data.py
@@ -39,6 +39,7 @@ def load_data(config: Config):
             try:
                 data[key] = ext_lookup[p.suffix](p)
             except (ValueError, YAMLError) as e:
+                logger.error('error parsing file %s: %s', p, e)
                 raise HarrierProblem(f'error reading {p} {e.__class__.__name__}: {e}') from e
             count += 1
     log_complete(start, 'data loaded', count)

--- a/harrier/dev.py
+++ b/harrier/dev.py
@@ -151,7 +151,8 @@ def update_site(args: UpdateArgs):  # noqa: C901 (ignore complexity)
                 log_complete(start, 'pages built', len(args.pages))
                 args.templates = args.templates or any(change != Change.deleted for change, _ in args.pages)
 
-            apply_page_generator(SOM, config)
+            extra_pages = apply_page_generator(SOM, config)
+            to_update = to_update | set(extra_pages.keys())
             SOM = apply_modifiers(SOM, config.extensions.som_modifiers)
             content_templates([SOM['pages'][k] for k in SOM['pages'] if k in to_update], config)
 
@@ -179,7 +180,7 @@ def is_within(location: Path, directory: Path):
 
 class HarrierWatcher(DefaultWatcher):
     def __init__(self, root_path):
-        self._used_paths = str(CONFIG.pages_dir), str(CONFIG.theme_dir)
+        self._used_paths = str(CONFIG.pages_dir), str(CONFIG.theme_dir), str(CONFIG.data_dir)
         super().__init__(root_path)
 
     def should_watch_dir(self, entry):

--- a/harrier/extensions.py
+++ b/harrier/extensions.py
@@ -127,7 +127,7 @@ class PageGeneratorModel(BaseModel):
 def apply_page_generator(som, config):
     from .build import get_page_data
     if not config.extensions.generate_pages:
-        return
+        return {}
     new_pages = {}
     for ext in config.extensions.generate_pages:
         for d in ext(som):
@@ -137,6 +137,7 @@ def apply_page_generator(som, config):
             path_ref = final_data.pop('path_ref')
             new_pages[path_ref] = final_data
     som['pages'].update(new_pages)
+    return new_pages
 
 
 class modify:

--- a/harrier/extensions.py
+++ b/harrier/extensions.py
@@ -22,6 +22,7 @@ class ExtensionError(HarrierProblem):
 class ExtType(str, Enum):
     config_modifiers = 'config_modifiers'
     som_modifiers = 'som_modifiers'
+    generate_pages = 'generate_pages'
     page_modifiers = 'page_modifiers'
     copy_modifiers = 'copy_modifiers'
     template_filters = 'template_filters'
@@ -43,6 +44,7 @@ class Extensions:
     def _set_extensions(self):
         self.config_modifiers = self._extensions[ExtType.config_modifiers]
         self.som_modifiers = self._extensions[ExtType.som_modifiers]
+        self.generate_pages = self._extensions[ExtType.generate_pages]
         self.page_modifiers = self._extensions[ExtType.page_modifiers]
         self.copy_modifiers = self._extensions[ExtType.copy_modifiers]
         self.template_filters = self._extensions[ExtType.template_filters]
@@ -62,6 +64,7 @@ class Extensions:
         self._extensions = {
             ExtType.config_modifiers: [],
             ExtType.som_modifiers: [],
+            ExtType.generate_pages: [],
             ExtType.page_modifiers: [],
             ExtType.copy_modifiers: [],
             ExtType.template_filters: {},
@@ -112,6 +115,18 @@ def apply_modifiers(obj, ext):
     return obj
 
 
+def apply_page_generator(som, config):
+    if not config.extensions.generate_pages:
+        return
+    new_pages = {}
+    for ext in config.extensions.generate_pages:
+        for p in ext(som):
+            # TODO validate that the data is correct here
+            path_ref = p.pop('path_ref')
+            new_pages[path_ref] = p
+    som['pages'].update(new_pages)
+
+
 class modify:
     @staticmethod
     def config(f):
@@ -121,6 +136,11 @@ class modify:
     @staticmethod
     def som(f):
         f.__extension__ = ExtType.som_modifiers
+        return f
+
+    @staticmethod
+    def generate_pages(f):
+        f.__extension__ = ExtType.generate_pages
         return f
 
     @classmethod

--- a/harrier/extensions.py
+++ b/harrier/extensions.py
@@ -134,7 +134,6 @@ def apply_page_generator(som, config):
             m = PageGeneratorModel.parse_obj(d)
             m.path = config.pages_dir / m.path
             final_data = get_page_data(m.path, config=config, file_content=m.content, **m.data)
-            debug(final_data)
             path_ref = final_data.pop('path_ref')
             new_pages[path_ref] = final_data
     som['pages'].update(new_pages)

--- a/harrier/extensions.py
+++ b/harrier/extensions.py
@@ -3,6 +3,7 @@ from enum import Enum
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import FunctionType
+from typing import Optional
 
 from jinja2 import (contextfilter, contextfunction, environmentfilter, environmentfunction, evalcontextfilter,
                     evalcontextfunction)
@@ -119,8 +120,8 @@ def apply_modifiers(obj, ext):
 
 class PageGeneratorModel(BaseModel):
     path: Path
-    content: str
-    extra_data: dict = {}
+    content: Optional[str]
+    data: dict = {}
 
 
 def apply_page_generator(som, config):
@@ -132,7 +133,8 @@ def apply_page_generator(som, config):
         for d in ext(som):
             m = PageGeneratorModel.parse_obj(d)
             m.path = config.pages_dir / m.path
-            final_data = get_page_data(m.path, config=config, content=m.content, **m.extra_data)
+            final_data = get_page_data(m.path, config=config, file_content=m.content, **m.data)
+            debug(final_data)
             path_ref = final_data.pop('path_ref')
             new_pages[path_ref] = final_data
     som['pages'].update(new_pages)

--- a/harrier/frontmatter.py
+++ b/harrier/frontmatter.py
@@ -1,9 +1,11 @@
+import logging
 import re
 
 from ruamel.yaml import YAMLError
 
 from .common import HarrierProblem, yaml
 
+logger = logging.getLogger('harrier.frontmatter')
 FRONT_MATTER_START_REGEX = re.compile(r'---[ \t]*(.*?)\n---[ \t]*\n', re.S)
 FRONT_MATTER_DIVIDER_REGEX = re.compile(r'\n?^--- ?([.\w_-]+) ?---[ \t]*\n', re.S | re.M)
 FRONT_MATTER_DIVIDER_EXTRA_REGEX = re.compile(r'(.*?)\n---[ \t]*\n', re.S | re.M)
@@ -16,6 +18,7 @@ def parse_front_matter(s, regex=FRONT_MATTER_START_REGEX):
     try:
         data = yaml.load(m.group(1)) or {}
     except YAMLError as e:
+        logger.error('error parsing YAML: %s', e)
         raise HarrierProblem(f'error parsing YAML: {e}') from e
     content = s[m.end():]
     return data, content

--- a/harrier/main.py
+++ b/harrier/main.py
@@ -14,7 +14,7 @@ from .common import completed_logger
 from .config import Mode, get_config
 from .data import load_data
 from .dev import adev
-from .extensions import apply_modifiers
+from .extensions import apply_modifiers, apply_page_generator
 from .render import render_pages
 
 logger = logging.getLogger('harrier.main')
@@ -69,9 +69,11 @@ def build(path: StrPath, steps: Set[BuildSteps]=None, mode: Optional[Mode]=None)
         path_lookup=get_path_lookup(config, pages),
         pages=pages,
         data=data_future and data_future.result(),
+        config=config,
     )
 
     if BuildSteps.extensions in steps:
+        apply_page_generator(som, config)
         som = apply_modifiers(som, config.extensions.som_modifiers)
 
     if som['pages'] is not None:

--- a/harrier/render.py
+++ b/harrier/render.py
@@ -70,7 +70,6 @@ class Renderer:
             inline_css=inline_css,
         )
         self.env.globals.update(self.config.extensions.template_functions)
-        self.som['config'] = config
         self.checked_dirs = set()
 
     def run(self):

--- a/harrier/version.py
+++ b/harrier/version.py
@@ -1,3 +1,3 @@
 from distutils.version import StrictVersion
 
-VERSION = StrictVersion('0.4.0')
+VERSION = StrictVersion('0.4.1')

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -309,3 +309,42 @@ def add_extra_pages(som):
         'index.html': 'hello\n',
         'binary_file': 'xxx',
     }
+
+
+def test_generate_pages_invalid(tmpdir):
+    mktree(tmpdir, {
+        'pages': {
+            'index.html': 'hello',
+        },
+        'extensions.py': """
+from pathlib import Path
+from harrier.extensions import modify
+
+@modify.generate_pages
+def add_extra_pages(som):
+    config: Config = som['config']
+    yield {
+        'path': Path('extra/index.md'),
+    }
+    """
+    })
+    with pytest.raises(ExtensionError):
+        build(str(tmpdir))
+
+
+def test_generate_pages_error(tmpdir):
+    mktree(tmpdir, {
+        'pages': {
+            'index.html': 'hello',
+        },
+        'extensions.py': """
+from pathlib import Path
+from harrier.extensions import modify
+
+@modify.generate_pages
+def add_extra_pages(som):
+    raise RuntimeError('xx')
+    """
+    })
+    with pytest.raises(ExtensionError):
+        build(str(tmpdir))

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -270,7 +270,7 @@ def test_generate_pages(tmpdir):
         'extensions.py': """
 from pathlib import Path
 from harrier.extensions import modify
-THIS_DIR = Path(__file__).parent
+THIS_DIR = Path(__file__).parent.resolve()
 
 @modify.generate_pages
 def add_extra_pages(som):
@@ -278,6 +278,19 @@ def add_extra_pages(som):
     yield {
         'path': Path('extra/index.md'),
         'content': '# this is a test\\n\\nwith of generating pages dynamically',
+    }
+    yield {
+        'path': Path('more/index.html'),
+        'content': 'testing {{ page.x }}',
+        'data': {
+            'uri': '/foo-bar-whatever',
+            'x': 123,
+        }
+    }
+    (THIS_DIR / 'pages' / 'binary_file').write_bytes(b'xxx')
+    yield {
+        'path': 'binary_file',
+        'content': None,
     }
     """
     })
@@ -290,5 +303,9 @@ def add_extra_pages(som):
                 '<p>with of generating pages dynamically</p>\n'
             ),
         },
+        'foo-bar-whatever': {
+            'index.html': 'testing 123\n'
+        },
         'index.html': 'hello\n',
+        'binary_file': 'xxx',
     }

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -276,13 +276,8 @@ THIS_DIR = Path(__file__).parent
 def add_extra_pages(som):
     config: Config = som['config']
     yield {
-        'path_ref': '/extra/index.html',
-        'outfile': THIS_DIR / 'dist/extra/index.html',
-        'infile': THIS_DIR / 'pages/extra.md',
-        'uri': '/extra',
-        'pass_through': False,
+        'path': Path('extra/index.md'),
         'content': '# this is a test\\n\\nwith of generating pages dynamically',
-        'template': None,
     }
     """
     })


### PR DESCRIPTION
To generate pages from data:

### tree
```
.
├── data
│   └── whatever.yml
├── extensions.py
├── pages
│   └── index.md
```

### whatever.yml
```yaml
- uri: '/foo'
  content: |
    # foo

    this is the foo content
- uri: '/bar'
  content: |
    # bar

    this is the bar content
```

### extensions.py
```py
from devtools import debug
from harrier.extensions import modify

@modify.generate_pages
def dynamic_pages(som):
    data: dict = som['data']
    for v in data['whatever']:
        debug(v)
        yield {
            'path': v['uri'][1:] + '.md',
            'content': v['content']
        }
```