### PR TITLE
Support for placeholders

### DIFF
--- a/harrier/build.py
+++ b/harrier/build.py
@@ -99,9 +99,18 @@ def get_page_data(p, *, config: Config, file_content: str=None, **extra_data):  
         'created': created,
     }
 
+    def _update_placeholders(d):
+        for key, v in d.items():
+            if isinstance(v, dict):
+                _update_placeholders(v)
+            else:
+                if isinstance(v, str) and v.startswith('@'):
+                    d[key] = data[v.lstrip('@')]
+
     for path_match, defaults in config.defaults.items():
         if path_match(path_ref):
             data.update(defaults)
+            _update_placeholders(data)
 
     pass_through = data.get('pass_through')
     if not pass_through and (html_output or maybe_render):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -147,6 +147,10 @@ def test_build_default_placeholders(tmpdir):
                     'd_foo': 'foo',
                 },
                 'list_attrs': ['foo', 'bar', '{{ title }}'],
+                'list_of_dicts_attr': [{
+                    'a_key': '{{ title }}-{{ test_attr }}',
+                    'b_key': 'foo bar',
+                }]
             }
         }
     )
@@ -184,6 +188,10 @@ def test_build_default_placeholders(tmpdir):
                 'd_foo': 'foo'
             },
             'list_attrs': ['foo', 'bar', 'Testing'],
+            'list_of_dicts_attr': [{
+                'a_key': 'Testing-Brain J',
+                'b_key': 'foo bar',
+            }],
             'template': None,
             'content': '# testing',
             'pass_through': False,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -123,6 +123,78 @@ def test_simple_render(tmpdir):
     assert gettree(tmpdir.join('dist')) != expected_tree
 
 
+def test_build_default_placeholders(tmpdir):
+    mktree(tmpdir, {
+        'dist/theme/assets/whatever.1234567.png': '**',
+        'pages': {
+            'foobar.md': '# hello\n\nthis is a test foo: {{ foo }}',
+            'posts/2032-06-01-testing.html': '# testing',
+            'static/image.png': '*',
+        },
+        'theme/templates/main.jinja': 'main, content:\n\n {{ content }}',
+    })
+    config = Config(
+        source_dir=str(tmpdir),
+        tmp_dir=str(tmpdir.join('tmp')),
+        foo='bar',
+        defaults={
+            '/posts/*': {
+                'uri': '/foobar/{slug}.html',
+                'test_attr': 'brain_j',
+                'foo_title': '@title',
+                'attrs': {
+                    'extra_attr': '@test_attr',
+                }
+            }
+        }
+    )
+
+    pages = build_pages(config)
+    content_templates(pages.values(), config)
+    source_dir = Path(tmpdir)
+    assert {
+               '/foobar.md': {
+                   'infile': source_dir / 'pages/foobar.md',
+                   'content_template': 'content/foobar.md',
+                   'title': 'Foobar',
+                   'slug': 'foobar',
+                   'created': CloseToNow(),
+                   'uri': '/foobar/',
+                   'template': None,
+                   'content': (
+                       '# hello\n'
+                       '\n'
+                       'this is a test foo: {{ foo }}'
+                   ),
+                   'pass_through': False,
+               },
+               '/posts/2032-06-01-testing.html': {
+                   'infile': source_dir / 'pages/posts/2032-06-01-testing.html',
+                   'content_template': 'content/posts/2032-06-01-testing.html',
+                   'title': 'Testing',
+                   'slug': 'testing',
+                   'created': datetime(2032, 6, 1, 0, 0),
+                   'uri': '/foobar/testing.html',
+                   'foo_title': 'Testing',
+                   'test_attr': 'brain_j',
+                   'attrs': {
+                       'extra_attr': 'brain_j',
+                   },
+                   'template': None,
+                   'content': '# testing',
+                   'pass_through': False,
+               },
+               '/static/image.png': {
+                   'infile': source_dir / 'pages/static/image.png',
+                   'title': 'image.png',
+                   'slug': 'image.png',
+                   'created': CloseToNow(),
+                   'uri': '/static/image.png',
+                   'pass_through': True,
+               }
+           } == pages
+
+
 def test_build_simple_som(tmpdir):
     mktree(tmpdir, {
         'dist/theme/assets/whatever.1234567.png': '**',

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -140,11 +140,13 @@ def test_build_default_placeholders(tmpdir):
         defaults={
             '/posts/*': {
                 'uri': '/foobar/{slug}.html',
-                'test_attr': 'brain_j',
-                'foo_title': '@title',
-                'attrs': {
-                    'extra_attr': '@test_attr',
-                }
+                'test_attr': 'Brain J',
+                'str_attr': '{{ title }}-{{ test_attr }}',
+                'dict_attrs': {
+                    'd_attr': '{{ test_attr }}',
+                    'd_foo': 'foo',
+                },
+                'list_attrs': ['foo', 'bar', '{{ title }}'],
             }
         }
     )
@@ -153,46 +155,48 @@ def test_build_default_placeholders(tmpdir):
     content_templates(pages.values(), config)
     source_dir = Path(tmpdir)
     assert {
-               '/foobar.md': {
-                   'infile': source_dir / 'pages/foobar.md',
-                   'content_template': 'content/foobar.md',
-                   'title': 'Foobar',
-                   'slug': 'foobar',
-                   'created': CloseToNow(),
-                   'uri': '/foobar/',
-                   'template': None,
-                   'content': (
-                       '# hello\n'
-                       '\n'
-                       'this is a test foo: {{ foo }}'
-                   ),
-                   'pass_through': False,
-               },
-               '/posts/2032-06-01-testing.html': {
-                   'infile': source_dir / 'pages/posts/2032-06-01-testing.html',
-                   'content_template': 'content/posts/2032-06-01-testing.html',
-                   'title': 'Testing',
-                   'slug': 'testing',
-                   'created': datetime(2032, 6, 1, 0, 0),
-                   'uri': '/foobar/testing.html',
-                   'foo_title': 'Testing',
-                   'test_attr': 'brain_j',
-                   'attrs': {
-                       'extra_attr': 'brain_j',
-                   },
-                   'template': None,
-                   'content': '# testing',
-                   'pass_through': False,
-               },
-               '/static/image.png': {
-                   'infile': source_dir / 'pages/static/image.png',
-                   'title': 'image.png',
-                   'slug': 'image.png',
-                   'created': CloseToNow(),
-                   'uri': '/static/image.png',
-                   'pass_through': True,
-               }
-           } == pages
+        '/foobar.md': {
+            'infile': source_dir / 'pages/foobar.md',
+            'content_template': 'content/foobar.md',
+            'title': 'Foobar',
+            'slug': 'foobar',
+            'created': CloseToNow(),
+            'uri': '/foobar/',
+            'template': None,
+            'content': (
+                '# hello\n'
+                '\n'
+                'this is a test foo: {{ foo }}'
+            ),
+            'pass_through': False,
+        },
+        '/posts/2032-06-01-testing.html': {
+            'infile': source_dir / 'pages/posts/2032-06-01-testing.html',
+            'content_template': 'content/posts/2032-06-01-testing.html',
+            'title': 'Testing',
+            'slug': 'testing',
+            'created': datetime(2032, 6, 1, 0, 0),
+            'uri': '/foobar/testing.html',
+            'str_attr': 'Testing-Brain J',
+            'test_attr': 'Brain J',
+            'dict_attrs': {
+                'd_attr': 'Brain J',
+                'd_foo': 'foo'
+            },
+            'list_attrs': ['foo', 'bar', 'Testing'],
+            'template': None,
+            'content': '# testing',
+            'pass_through': False,
+        },
+        '/static/image.png': {
+            'infile': source_dir / 'pages/static/image.png',
+            'title': 'image.png',
+            'slug': 'image.png',
+            'created': CloseToNow(),
+            'uri': '/static/image.png',
+            'pass_through': True,
+        }
+    } == pages
 
 
 def test_build_simple_som(tmpdir):


### PR DESCRIPTION
Functionality to add placeholders to the defaults.

For instance, setting defaults to 

```yaml
'/features/*':
  name: '@title',
```
will set `page.name` equal to `page.title`.