### PR TITLE
Use webpack.config if provided

### DIFF
--- a/harrier/assets.py
+++ b/harrier/assets.py
@@ -154,9 +154,9 @@ def webpack_configuration(config: Config, watch: bool):
         prod and '--optimize-minimize',
     )
     if wp.config:
-        args += ('--config', f'./{wp.config.relative_to(config.source_dir)}')
+        args += '--config', f'./{wp.config.relative_to(config.source_dir)}'
     else:
-        args += ('--entry', f'./{wp.entry.relative_to(config.source_dir)}', '--output-path', wp.output_path)
+        args += '--entry', f'./{wp.entry.relative_to(config.source_dir)}', '--output-path', wp.output_path
     env = dict(
         **os.environ,
         **{

--- a/harrier/assets.py
+++ b/harrier/assets.py
@@ -144,10 +144,6 @@ def webpack_configuration(config: Config, watch: bool):
         wp.cli,
         '--context',
         config.source_dir,
-        '--entry',
-        f'./{wp.entry.relative_to(config.source_dir)}',
-        '--output-path',
-        wp.output_path,
         output_filename and '--output-filename',
         output_filename,
         '--devtool',
@@ -156,9 +152,11 @@ def webpack_configuration(config: Config, watch: bool):
         config.mode.value,
         watch and '--watch',
         prod and '--optimize-minimize',
-        wp.config and '--config',
-        wp.config and f'./{wp.config.relative_to(config.source_dir)}',
     )
+    if wp.config:
+        args += ('--config', f'./{wp.config.relative_to(config.source_dir)}')
+    else:
+        args += ('--entry', f'./{wp.entry.relative_to(config.source_dir)}', '--output-path', wp.output_path)
     env = dict(
         **os.environ,
         **{

--- a/harrier/config.py
+++ b/harrier/config.py
@@ -25,10 +25,10 @@ class Mode(str, Enum):
 
 class WebpackConfig(BaseModel):
     cli: Path = None
-    entry: Path = 'js/index.js'
+    entry: Optional[Path] = 'js/index.js'
     output_path: Path = 'theme'
-    dev_output_filename: Optional[str] = 'main.js'
-    prod_output_filename: Optional[str] = 'main.[hash].js'
+    dev_output_filename: Optional[str] = '[name].js'
+    prod_output_filename: Optional[str] = '[name].[hash].js'
     config: Path = None
     run: bool = True
 
@@ -129,17 +129,17 @@ class Config(BaseModel):
         elif not webpack.cli.exists():
             raise ValueError(f'webpack cli path set but does not exist "{webpack.cli}", not running webpack')
 
-        webpack.entry = values['theme_dir'] / webpack.entry
-        if not webpack.entry.exists() and webpack.run:
-            logger.warning('webpack entry point "%s" does not exist, not running webpack', webpack.entry)
-            webpack.run = False
-
         if webpack.config:
             webpack.config = values['source_dir'] / webpack.config
             if not webpack.config.exists():
                 raise ValueError(f'webpack config set but does not exist "{webpack.config}", not running webpack')
-
-        webpack.output_path = values['dist_dir'] / webpack.output_path
+            logger.info('webpack config file found')
+        else:
+            webpack.entry = values['theme_dir'] / webpack.entry
+            if not webpack.entry.exists() and webpack.run:
+                logger.warning('webpack entry point "%s" does not exist, not running webpack', webpack.entry)
+                webpack.run = False
+            webpack.output_path = values['dist_dir'] / webpack.output_path
         return webpack
 
     @validator('build_time', pre=True, always=True)


### PR DESCRIPTION
At the moment, we can define args in harrier.yml that are overridden by the config file, and are therefore made redundant. With this PR, we only add the args for entry and output file if the config file isn't provided.

Needed for https://github.com/tutorcruncher/tutorcruncher.com/pull/1324